### PR TITLE
AppOps: fix wifi scan op

### DIFF
--- a/core/java/android/app/AppOpsManager.java
+++ b/core/java/android/app/AppOpsManager.java
@@ -219,7 +219,7 @@ public class AppOpsManager {
             OP_WRITE_CALL_LOG,
             OP_READ_CALENDAR,
             OP_WRITE_CALENDAR,
-            OP_COARSE_LOCATION,
+            OP_WIFI_SCAN,
             OP_POST_NOTIFICATION,
             OP_COARSE_LOCATION,
             OP_CALL_PHONE,
@@ -370,7 +370,7 @@ public class AppOpsManager {
             android.Manifest.permission.READ_CALENDAR,
             android.Manifest.permission.WRITE_CALENDAR,
             null, // no permission required for notifications
-            android.Manifest.permission.ACCESS_WIFI_STATE,
+            null, // no permission for wifi scan available
             null, // neighboring cells shares the coarse location perm
             android.Manifest.permission.CALL_PHONE,
             android.Manifest.permission.READ_SMS,


### PR DESCRIPTION
There's no direct permission tied to it and fix the op-to-switch entry.
http://review.cyanogenmod.org/#/c/126391/
